### PR TITLE
Build(deps): Bump the pointercrate group with 8 updates (#179)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,15 +237,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cc"
-version = "1.1.19"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d74707dde2ba56f86ae90effb3b43ddd369504387e718014de010cec7959800"
+checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
 dependencies = [
  "shlex",
 ]
@@ -1101,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.60"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1912,9 +1912,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+checksum = "d30538d42559de6b034bc76fd6dd4c38961b1ee5c6c56e3808c50128fdbc22ce"
 
 [[package]]
 name = "powerfmt"
@@ -2388,9 +2388,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3062,9 +3062,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.20"
+version = "0.22.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf"
 dependencies = [
  "indexmap",
  "serde",
@@ -3207,9 +3207,9 @@ checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
@@ -3222,9 +3222,9 @@ checksum = "52ea75f83c0137a9b98608359a5f1af8144876eb67bcb1ce837368e906a9f524"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unicode_categories"


### PR DESCRIPTION
Bumps the pointercrate group with 8 updates:

| Package | From | To |
| --- | --- | --- |
| [bytes](https://github.com/tokio-rs/bytes) | `1.7.1` | `1.7.2` | | [cc](https://github.com/rust-lang/cc-rs) | `1.1.19` | `1.1.21` | | [iana-time-zone](https://github.com/strawlab/iana-time-zone) | `0.1.60` | `0.1.61` | | [portable-atomic](https://github.com/taiki-e/portable-atomic) | `1.7.0` | `1.8.0` | | [security-framework-sys](https://github.com/kornelski/rust-security-framework) | `2.11.1` | `2.12.0` | | [toml_edit](https://github.com/toml-rs/toml) | `0.22.20` | `0.22.21` | | [unicode-normalization](https://github.com/unicode-rs/unicode-normalization) | `0.1.23` | `0.1.24` | | [unicode-xid](https://github.com/unicode-rs/unicode-xid) | `0.2.5` | `0.2.6` |


Updates `bytes` from 1.7.1 to 1.7.2
- [Release notes](https://github.com/tokio-rs/bytes/releases)
- [Changelog](https://github.com/tokio-rs/bytes/blob/master/CHANGELOG.md)
- [Commits](https://github.com/tokio-rs/bytes/compare/v1.7.1...v1.7.2)

Updates `cc` from 1.1.19 to 1.1.21
- [Release notes](https://github.com/rust-lang/cc-rs/releases)
- [Changelog](https://github.com/rust-lang/cc-rs/blob/main/CHANGELOG.md)
- [Commits](https://github.com/rust-lang/cc-rs/compare/cc-v1.1.19...cc-v1.1.21)

Updates `iana-time-zone` from 0.1.60 to 0.1.61
- [Changelog](https://github.com/strawlab/iana-time-zone/blob/main/CHANGELOG.md)
- [Commits](https://github.com/strawlab/iana-time-zone/compare/v0.1.60...v0.1.61)

Updates `portable-atomic` from 1.7.0 to 1.8.0
- [Release notes](https://github.com/taiki-e/portable-atomic/releases)
- [Changelog](https://github.com/taiki-e/portable-atomic/blob/main/CHANGELOG.md)
- [Commits](https://github.com/taiki-e/portable-atomic/compare/v1.7.0...v1.8.0)

Updates `security-framework-sys` from 2.11.1 to 2.12.0
- [Release notes](https://github.com/kornelski/rust-security-framework/releases)
- [Commits](https://github.com/kornelski/rust-security-framework/commits)

Updates `toml_edit` from 0.22.20 to 0.22.21
- [Commits](https://github.com/toml-rs/toml/compare/v0.22.20...v0.22.21)

Updates `unicode-normalization` from 0.1.23 to 0.1.24
- [Commits](https://github.com/unicode-rs/unicode-normalization/compare/v0.1.23...v0.1.24)

Updates `unicode-xid` from 0.2.5 to 0.2.6
- [Changelog](https://github.com/unicode-rs/unicode-xid/blob/master/CHANGELOG.md)
- [Commits](https://github.com/unicode-rs/unicode-xid/compare/v0.2.5...v0.2.6)

---
updated-dependencies:
- dependency-name: bytes dependency-type: indirect update-type: version-update:semver-patch dependency-group: pointercrate
- dependency-name: cc dependency-type: indirect update-type: version-update:semver-patch dependency-group: pointercrate
- dependency-name: iana-time-zone dependency-type: indirect update-type: version-update:semver-patch dependency-group: pointercrate
- dependency-name: portable-atomic dependency-type: indirect update-type: version-update:semver-minor dependency-group: pointercrate
- dependency-name: security-framework-sys dependency-type: indirect update-type: version-update:semver-minor dependency-group: pointercrate
- dependency-name: toml_edit dependency-type: indirect update-type: version-update:semver-patch dependency-group: pointercrate
- dependency-name: unicode-normalization dependency-type: indirect update-type: version-update:semver-patch dependency-group: pointercrate
- dependency-name: unicode-xid dependency-type: indirect update-type: version-update:semver-patch dependency-group: pointercrate ...

## License Acceptance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
